### PR TITLE
Use correct case in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Headers can be specified as a normal header via GET, or appended to the query st
 'X-Plex-' to the query parameter. For 'path', you would add &X-Plex-path=somePath to the query.
 
 
-## /Devices
+## /devices
 
 Returns a standard Plex-formatted Mediacontainer, populated with a list of 
 cast devices as <Device> nodes in the primary mediacontainer.
@@ -39,18 +39,18 @@ Device data is retrieved from cache and re-scanned every 10 minutes.
 
 Does not require any other headers.
 
-## /Rescan
+## /rescan
 
 Rescans all devices and stores their information into cache, then returns the 
 same data as found from the /Devices endpoint.
 
 TODO:
-## /Play
+## /play
 
 Plays media from a Plex Media server. Requires a bunch of headers that I have to look up.
 
 TODO:
-## /Cmd
+## /cmd
 
 Issues a media control command. Need to grab a list of the proper formatting.
 
@@ -59,7 +59,7 @@ of the cast device to control.
 
 Should add an option for friendlyName as well.
 
-## /Broadcast
+## /broadcast
 
 Broadcast an audio clip to all audio cast devices in cache.
 
@@ -67,13 +67,13 @@ Required headers: "path", where "path" is a publicly accessible URL to MP3-encod
 
 TODO: Add optional audio type for non-mp3.
 
-## /Audio
+## /audio
 
 Plays an audio clip to the specified cast device.
 
 Required headers: "path", "uri"
 
-## /Status
+## /status
 
 Fetches the current status of the specified device
 


### PR DESCRIPTION
The APIs are `/chromecast/foo`, not `/chromecast/Foo` =)